### PR TITLE
csm-texel-increments

### DIFF
--- a/assets/scenes/sampleScene.willmap
+++ b/assets/scenes/sampleScene.willmap
@@ -6,7 +6,7 @@
     },
     "metadata": {
         "name": "Test Scene",
-        "created": "2025-02-16 00:27:09",
+        "created": "2025-02-18 23:49:45",
         "formatVersion": 1
     },
     "gameObjects": {
@@ -73,15 +73,15 @@
                 "name": "Sphere",
                 "transform": {
                     "position": {
-                        "x": 0.0,
-                        "y": 2.0,
-                        "z": 0.0
+                        "x": -0.0439082570374012,
+                        "y": 1.9999991655349731,
+                        "z": -0.48458972573280334
                     },
                     "rotation": {
-                        "x": 0.0,
-                        "y": 0.0,
-                        "z": 0.0,
-                        "w": 1.0
+                        "x": -0.5344635844230652,
+                        "y": 0.006479519419372082,
+                        "z": 0.01267132069915533,
+                        "w": 0.8450716733932495
                     },
                     "scale": {
                         "x": 1.0,
@@ -104,6 +104,32 @@
                         "z": 0.0
                     }
                 }
+            },
+            {
+                "id": 3,
+                "name": "GameObject_3",
+                "transform": {
+                    "position": {
+                        "x": 2.299999952316284,
+                        "y": 2.0,
+                        "z": 3.0999999046325684
+                    },
+                    "rotation": {
+                        "x": 0.0,
+                        "y": 0.0,
+                        "z": 0.0,
+                        "w": 1.0
+                    },
+                    "scale": {
+                        "x": 1.0,
+                        "y": 1.0,
+                        "z": 1.0
+                    }
+                },
+                "renderReference": 786709467,
+                "renderMeshIndex": 1,
+                "renderIsVisible": true,
+                "renderIsShadowCaster": true
             }
         ]
     },

--- a/shaders/deferredResolve.comp
+++ b/shaders/deferredResolve.comp
@@ -112,6 +112,8 @@ void main() {
     vec3 diffuse = Lambert(kD, albedo.xyz);
 
     // SHADOWS
+    float normalOffsetScale = max(0.05f, dot(normal, L) * 0.05f);
+    vec3 offsetPosition = position + normal * normalOffsetScale;
     float _tempShadowFactor = getShadowFactorBlend(pushConstants.pcfLevel, position, sceneData.view, shadowCascadeData.cascadeSplits, shadowCascadeData.lightViewProj, shadowMapSampler, shadowCascadeData.nearShadowPlane, shadowCascadeData.farShadowPlane);
     float shadowFactor = clamp(smoothstep(-0.15f, 0.5f, dot(N, L)) * _tempShadowFactor, 0, 1);
 

--- a/shaders/include/shadows.glsl
+++ b/shaders/include/shadows.glsl
@@ -28,17 +28,6 @@ int getCascadeLevel(vec3 worldPos, mat4 viewMatrix, CascadeSplit cascadeSplits[4
     return selectCascadeLevel(viewDepth, cascadeSplits);
 }
 
-float getShadowFactor(vec3 worldPos, mat4 cascadeLightViewProj, sampler2DShadow shadowMap, float cascadeNearPlane, float cascadeFarPlane) {
-    vec4 lightSpacePos = cascadeLightViewProj * vec4(worldPos, 1.0);
-    vec3 projCoords = lightSpacePos.xyz / lightSpacePos.w;
-    projCoords.xy = projCoords.xy * 0.5 + 0.5;
-    float currentDepth = projCoords.z;
-    if (projCoords.z > cascadeFarPlane) { return 1.0; }
-    if (projCoords.z < cascadeNearPlane) { return 1.0; }
-    float shadow = texture(shadowMap, vec3(projCoords.xy, currentDepth));
-    return shadow;
-}
-
 float getShadowFactorBlend(int pcfLevel, vec3 worldPos, mat4 sceneViewMatrix, CascadeSplit[4] splits, mat4[4] lightMatrices, sampler2DShadow[4] shadowMaps, float cascadeNearPlane, float cascadeFarPlane) {
     vec4 viewPos = sceneViewMatrix * vec4(worldPos, 1.0);
     float viewSpaceDepth = abs(viewPos.z);
@@ -119,25 +108,4 @@ float getShadowFactorBlend(int pcfLevel, vec3 worldPos, mat4 sceneViewMatrix, Ca
         }
     }
     return shadowFactor1;
-}
-
-float getShadowFactorPCF5(vec3 worldPos, mat4 cascadeLightViewProj, sampler2DShadow shadowMap, float cascadeNearPlane, float cascadeFarPlane) {
-    vec4 lightSpacePos = cascadeLightViewProj * vec4(worldPos, 1.0);
-    vec3 projCoords = lightSpacePos.xyz / lightSpacePos.w;
-    projCoords.xy = projCoords.xy * 0.5 + 0.5;
-    float currentDepth = projCoords.z;
-    if (projCoords.z > cascadeFarPlane) { return 1.0; }
-    if (projCoords.z < cascadeNearPlane) { return 1.0; }
-
-    float shadow = 0.0;
-    vec2 texelSize = 1.0 / textureSize(shadowMap, 0);
-
-    const int halfKernel = 2;
-    for (int x = -halfKernel; x <= halfKernel; x++) {
-        for (int y = -halfKernel; y <= halfKernel; y++) {
-            vec2 offset = vec2(x, y) * texelSize;
-            shadow += texture(shadowMap, vec3(projCoords.xy + offset, currentDepth));
-        }
-    }
-    return shadow / ((2 * halfKernel + 1) * (2 * halfKernel + 1));
 }

--- a/shaders/include/shadows.glsl
+++ b/shaders/include/shadows.glsl
@@ -13,13 +13,14 @@ float getViewSpaceDepth(vec3 worldPos, mat4 viewMatrix) {
 }
 
 int selectCascadeLevel(float viewSpaceDepth, CascadeSplit[4] cascadeSplits) {
-    for (int i = 0; i < 4; i++) {
-        if (viewSpaceDepth >= cascadeSplits[i].nearPlane && viewSpaceDepth <= cascadeSplits[i].farPlane) {
-            return i;
-        }
-    }
+    vec4 comparisons = vec4(
+    viewSpaceDepth <= cascadeSplits[0].farPlane,
+    viewSpaceDepth <= cascadeSplits[1].farPlane,
+    viewSpaceDepth <= cascadeSplits[2].farPlane,
+    viewSpaceDepth <= cascadeSplits[3].farPlane
+    );
 
-    return 4;
+    return 4 - int(dot(comparisons, vec4(1.0)));
 }
 
 int getCascadeLevel(vec3 worldPos, mat4 viewMatrix, CascadeSplit cascadeSplits[4]) {
@@ -52,12 +53,14 @@ float getShadowFactorBlend(int pcfLevel, vec3 worldPos, mat4 sceneViewMatrix, Ca
     }
 
     int cascadeLevel = -1;
-    for (int i = 0; i < 4; i++) {
-        if (viewSpaceDepth >= splits[i].nearPlane && viewSpaceDepth <= splits[i].farPlane) {
-            cascadeLevel = i;
-            break;
-        }
-    }
+    vec4 comparisons = vec4(
+    viewSpaceDepth <= splits[0].farPlane,
+    viewSpaceDepth <= splits[1].farPlane,
+    viewSpaceDepth <= splits[2].farPlane,
+    viewSpaceDepth <= splits[3].farPlane
+    );
+
+    cascadeLevel = 4 - int(dot(comparisons, vec4(1.0)));
 
     if (cascadeLevel == -1) {
         // Shouldn't be legal

--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -488,6 +488,7 @@ void Engine::draw(float deltaTime)
     vk_helpers::transitionImage(cmd, drawImage.image, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_COLOR_BIT);
     const deferred_resolve::DeferredResolveDrawInfo deferredResolveDrawInfo{
         deferredDebug,
+        csmPcf,
         sceneDataDescriptorBuffer.getDescriptorBufferBindingInfo(),
         sceneDataDescriptorBuffer.getDescriptorBufferSize() * currentFrameOverlap,
         environmentMap->getDiffSpecMapDescriptorBuffer().getDescriptorBufferBindingInfo(),

--- a/src/core/engine.h
+++ b/src/core/engine.h
@@ -138,7 +138,7 @@ private: // Rendering
 private: // Debug
     bool bEnableTaa{true};
     bool bEnableDebugFrustumCullDraw{false};
-    int32_t csmPcf{5};
+    int32_t csmPcf{1};
     int32_t deferredDebug{0};
 
     void hotReloadShaders() const;

--- a/src/core/engine.h
+++ b/src/core/engine.h
@@ -138,6 +138,7 @@ private: // Rendering
 private: // Debug
     bool bEnableTaa{true};
     bool bEnableDebugFrustumCullDraw{false};
+    int32_t csmPcf{5};
     int32_t deferredDebug{0};
 
     void hotReloadShaders() const;

--- a/src/renderer/imgui_wrapper.cpp
+++ b/src/renderer/imgui_wrapper.cpp
@@ -228,7 +228,7 @@ void ImguiWrapper::imguiInterface(Engine* engine)
             if (ImGui::BeginTabItem("Shadows")) {
                 ImGui::Text("Cascaded Shadow Map");
                 ImGui::DragInt("CSM PCF Level", &engine->csmPcf, 2, 1, 7);
-                ImGui::InputFloat3("Main Light Direction", engine->mainLight.direction);
+                ImGui::DragFloat3("Main Light Direction", engine->mainLight.direction, 0.1);
                 ImGui::InputFloat2("Cascade 1 Bias", shadows::CASCADE_BIAS[0]);
                 ImGui::InputFloat2("Cascade 2 Bias", shadows::CASCADE_BIAS[1]);
                 ImGui::InputFloat2("Cascade 3 Bias", shadows::CASCADE_BIAS[2]);

--- a/src/renderer/imgui_wrapper.cpp
+++ b/src/renderer/imgui_wrapper.cpp
@@ -227,6 +227,7 @@ void ImguiWrapper::imguiInterface(Engine* engine)
 
             if (ImGui::BeginTabItem("Shadows")) {
                 ImGui::Text("Cascaded Shadow Map");
+                ImGui::DragInt("CSM PCF Level", &engine->csmPcf, 2, 1, 7);
                 ImGui::InputFloat3("Main Light Direction", engine->mainLight.direction);
                 ImGui::InputFloat2("Cascade 1 Bias", shadows::CASCADE_BIAS[0]);
                 ImGui::InputFloat2("Cascade 2 Bias", shadows::CASCADE_BIAS[1]);
@@ -633,6 +634,9 @@ void ImguiWrapper::displayGameObject(Engine* engine, const Scene* scene, IHierar
         ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.2f, 0.2f, 0.2f, 1.0f));
         ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1, 0, 0, 1));
         if (ImGui::Button("X")) {
+            if (selectedItem == obj) {
+                selectedItem = nullptr;
+            }
             engine->hierarchicalDeletionQueue.push_back(obj);
         }
         ImGui::PopStyleColor(1);
@@ -646,35 +650,6 @@ void ImguiWrapper::displayGameObject(Engine* engine, const Scene* scene, IHierar
         }
     } else {
         ImGui::Text("  ");
-    }
-
-    ImGui::SameLine();
-    if (const auto* physBody = dynamic_cast<IPhysicsBody*>(obj)) {
-        ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.2f, 0.2f, 0.2f, 1.0f));
-        ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.7f, 0.7f, 1.0f, 1.0f));
-        if (ImGui::Button("P")) {
-            ImGui::OpenPopup("MotionTypePopup");
-        }
-        ImGui::PopStyleColor(2);
-
-        if (ImGui::BeginPopup("MotionTypePopup")) {
-            auto physics = physics::Physics::Get();
-            JPH::EMotionType currentType = physics->getMotionType(physBody);
-
-            if (ImGui::MenuItem("Static", nullptr, currentType == JPH::EMotionType::Static)) {
-                physics->setMotionType(physBody, JPH::EMotionType::Static, JPH::EActivation::DontActivate);
-            }
-            if (ImGui::MenuItem("Kinematic", nullptr, currentType == JPH::EMotionType::Kinematic)) {
-                physics->setMotionType(physBody, JPH::EMotionType::Kinematic, JPH::EActivation::DontActivate);
-            }
-            if (ImGui::MenuItem("Dynamic", nullptr, currentType == JPH::EMotionType::Dynamic)) {
-                physics->setMotionType(physBody, JPH::EMotionType::Dynamic, JPH::EActivation::Activate);
-            }
-
-            ImGui::EndPopup();
-        }
-    } else {
-        ImGui::Text(" ");
     }
 
 

--- a/src/renderer/lighting/shadows/shadows.cpp
+++ b/src/renderer/lighting/shadows/shadows.cpp
@@ -5,8 +5,8 @@
 #include "shadows.h"
 
 float will_engine::shadows::CASCADE_BIAS[SHADOW_CASCADE_COUNT][2] = {
-    {750.0f, 6.0f},
     {400.0f, 4.0f},
-    {250.0f, 3.0f},
+    {200.0f, 3.0f},
+    {150.0f, 2.5f},
     {100.0f, 2.0f},
 };

--- a/src/renderer/lighting/shadows/shadows.h
+++ b/src/renderer/lighting/shadows/shadows.h
@@ -15,7 +15,7 @@ static constexpr uint32_t SHADOW_CASCADE_COUNT = 4;
 static constexpr float CASCADE_NEAR_PLANE = 0.1f;
 static constexpr float CASCADE_FAR_PLANE = 200.0f;
 extern float CASCADE_BIAS[SHADOW_CASCADE_COUNT][2];
-static constexpr VkExtent2D CASCADE_EXTENT{2048, 2048};
+static constexpr VkExtent2D CASCADE_EXTENT{4096, 4096};
 static constexpr VkFormat CASCADE_DEPTH_FORMAT{VK_FORMAT_D32_SFLOAT};
 }
 

--- a/src/renderer/pipelines/deferred_resolve/deferred_resolve.cpp
+++ b/src/renderer/pipelines/deferred_resolve/deferred_resolve.cpp
@@ -109,7 +109,7 @@ void will_engine::deferred_resolve::DeferredResolvePipeline::draw(VkCommandBuffe
     pushConstants.height = RENDER_EXTENT_HEIGHT;
     pushConstants.deferredDebug = drawInfo.deferredDebug;
     pushConstants.disableShadows = 0;
-    pushConstants.pcfLevel = 5;
+    pushConstants.pcfLevel = drawInfo.csmPcf;
     pushConstants.nearPlane = drawInfo.nearPlane;
     pushConstants.farPlane = drawInfo.farPlane;
 

--- a/src/renderer/pipelines/deferred_resolve/deferred_resolve.h
+++ b/src/renderer/pipelines/deferred_resolve/deferred_resolve.h
@@ -31,7 +31,7 @@ struct DeferredResolvePushConstants
     int32_t height{900};
     int32_t deferredDebug{0};
     int32_t disableShadows{0};
-    int32_t pcfLevel{5};
+    int32_t pcfLevel{1};
     float nearPlane{1000.0f};
     float farPlane{0.1f};
 };

--- a/src/renderer/pipelines/deferred_resolve/deferred_resolve.h
+++ b/src/renderer/pipelines/deferred_resolve/deferred_resolve.h
@@ -39,6 +39,7 @@ struct DeferredResolvePushConstants
 struct DeferredResolveDrawInfo
 {
     int32_t deferredDebug{0};
+    int32_t csmPcf{0};
     VkDescriptorBufferBindingInfoEXT sceneDataBinding{};
     VkDeviceSize sceneDataOffset{0};
     VkDescriptorBufferBindingInfoEXT environmentIBLBinding{};

--- a/src/util/math_constants.h
+++ b/src/util/math_constants.h
@@ -5,6 +5,7 @@
 #ifndef MATH_CONSTANTS_H
 #define MATH_CONSTANTS_H
 
+#include <glm/vec3.hpp>
 #include <vulkan/vulkan.h>
 
 namespace will_engine {
@@ -43,6 +44,8 @@ namespace will_engine {
 
     constexpr int32_t INDEX_NONE = -1;
     constexpr uint64_t INDEX64_NONE = INT64_MAX;
+
+    constexpr auto GLOBAL_UP = glm::vec3(0.0f, 1.0f, 0.0f);
 }
 
 #endif //MATH_CONSTANTS_H


### PR DESCRIPTION
Improve cascaded shadow maps by fitting the shadow map to a fixed texel size, preventing the edges of shadows from "zigzagging".
Addresses #6